### PR TITLE
Fixed: Error to activate plugin

### DIFF
--- a/includes/widget.php
+++ b/includes/widget.php
@@ -214,7 +214,7 @@ class Sfmsb_Widget extends WP_Widget {
 					});
 				</script>
 			
-			<?
+			<?php
 		
 		}
 


### PR DESCRIPTION
Fixed error: "Parse error: syntax error, unexpected end of file"
