### PR TITLE
The styling now only applies to the widget content

### DIFF
--- a/includes/widget.php
+++ b/includes/widget.php
@@ -388,6 +388,8 @@ class Sfmsb_Widget extends WP_Widget {
 			
 				// ** do_action
 				do_action('sfmsb_widget_pre_buttons');
+				
+				if ( !empty( $title ) ) { echo $before_title . $title  . $after_title; };
 		
 				echo '<div';
 				echo ' class="sfmsb-follow-social-buttons sfmsb-' . $instance['position'] . ' sfmsb-' . $instance['style'] . ' ' . $instance['size'] . ' sfmsb-' . $instance['layout']   . '"';
@@ -397,8 +399,6 @@ class Sfmsb_Widget extends WP_Widget {
 				}
 
 				echo '>';
-				
-				if ( !empty( $title ) ) { echo $before_title . $title  . $after_title; };
 				
 				switch( TRUE ) {
 						


### PR DESCRIPTION
... and not to the widget title.

To my mind, the widget title shouldn't be concerned about the "social icons" styling. That's why I moved the title before the SFMSB `<div>` container. This also makes the HTML structure more regular compared to the other built-in widgets because the `<div>` container breaks the style of my template.
